### PR TITLE
restrict builds to arm64 linux

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on:  self-hosted
+    runs-on:  [self-hosted,linux,arm64]
 
     strategy:
       # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.


### PR DESCRIPTION
to test this enable public repositories usage of workgroup self hosted runenrs.
no job should go to additiona runners (they are both windows and linux, x64)